### PR TITLE
Move compute_boltzmann_factor out of loop

### DIFF
--- a/Rloop_equilibrium_model.cpp
+++ b/Rloop_equilibrium_model.cpp
@@ -201,8 +201,8 @@ void Rloop_equilibrium_model::compute_structure(vector<char>& sequence, const st
             b_0 = sequence.begin();
         }
         structure.free_energy += step_forward_bps(b_0,b_0+1);
-        structure.boltzmann_factor = compute_boltzmann_factor(structure.free_energy,T);
     }
+    structure.boltzmann_factor = compute_boltzmann_factor(structure.free_energy,T);
 }
 
 void Rloop_equilibrium_model::compute_residuals(Structure &structure){


### PR DESCRIPTION
Hey Robert, 

Been looking around in the Rlooper code and happened across this. It looks like to me the boltzmann factor is getting calculated every iteration of the for loop in ` Rloop_equilibrium_model::compute_structure` method but only seems dependent on the *total* free energy not the free energy calculation at every iteration of the loop.

If this assumption is correct, we save a bit of time by only computing the boltzmann factor once. Code as is would still produce the same result except only the last calculation (in the last iteration of the loop) would actually be used.